### PR TITLE
[roscontrol_sot_talos] Fix starting script on 16.04

### DIFF
--- a/roscontrol_sot_talos/scripts/start_talos_gazebo_16_04.py
+++ b/roscontrol_sot_talos/scripts/start_talos_gazebo_16_04.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 # O. Stasse 17/01/2020
 # LAAS, CNRS
 
@@ -42,7 +42,7 @@ gazebo_unpause_physics = rospy.ServiceProxy('/gazebo/unpause_physics', Empty)
 gazebo_unpause_physics()
 
 # Start roscontrol
-launch_bringup = roslaunch.parent.ROSLaunchParent(uuid, ["/opt/openrobots/share/talos_bringup/launch/talos_bringup.launch"])
+launch_bringup = roslaunch.parent.ROSLaunchParent(uuid, ["/opt/openrobots/share/talos_data/launch/talos_bringup.launch"])
 launch_bringup.start()
 rospy.loginfo("talos_bringup started")
 


### PR DESCRIPTION
Start with talos_data instead of talos_bringup which starting packages not integrated
in robotpkg