### PR TITLE
[fix] Robot_state_publisher

### DIFF
--- a/sot_pyrene_bringup/launch/geometric_simu_context.launch
+++ b/sot_pyrene_bringup/launch/geometric_simu_context.launch
@@ -29,7 +29,7 @@
     -->
   <node name="robot_state_publisher"
 	pkg="robot_state_publisher"
-	type="state_publisher"
+	type="robot_state_publisher"
 	respawn="true">
     <param name="tf_prefix" value="" />
   </node>


### PR DESCRIPTION
State_publisher is deprecated (since Groovy)
Robot_state_publisher is the new name for the executable