### PR TITLE
[roscontrol_sot_talos] Update sot_talos_params.yaml

### DIFF
--- a/roscontrol_sot_talos/config/sot_talos_params.yaml
+++ b/roscontrol_sot_talos/config/sot_talos_params.yaml
@@ -75,5 +75,4 @@ sot_controller:
     - name: head_2_joint
       des_pos: 0.0   
   dt: 0.001
-  jitter: 0.0004
-  
+  subsampling: 2


### PR DESCRIPTION
  to changes in roscontrol_sot.
  parameter jitter has become useless, add parameter subsampling
  instead.

This follows https://github.com/stack-of-tasks/roscontrol_sot/pull/36.